### PR TITLE
Add a deploy task to wordpress svn using grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,9 +45,41 @@ module.exports = function(grunt) {
                 updatePoFiles: false
             }
         }
-    }
+    },
+    wp_plugin: {
+      deploy: {
+        options: {
+          assets_dir: 'assets/wp',
+          deploy_dir: 'deploy',   // Relative path to your deploy directory (required).
+          plugin_slug: 'wc-skroutz-analytics',
+          svn_username: 'skroutz',
+          svn_repository: 'https://plugins.svn.wordpress.org/skroutz-analytics-woocommerce/'
+        }
+      }
+    },
+    copy: {
+      main: {
+        files: [
+          {
+            expand: true,
+            src: ['**', '!tmp/**', '!Gruntfile.js', '!node_modules/**', '!package.json', '!README.md', '!*.sublime*', '!assets/wp/**'],
+            dest: 'deploy/'
+          },
+        ],
+      },
+    },
+    clean: ['deploy/**', 'tmp/**']
   });
 
   // Load plugins
-  grunt.loadNpmTasks( 'grunt-wp-i18n' );
+  grunt.loadNpmTasks('grunt-wp-i18n');
+  grunt.loadNpmTasks('grunt-wp-plugin');
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-contrib-clean');
+
+  grunt.registerTask('deploy', 'Create a deploy dir, deploy to wordpress svn and clean up', function() {
+    grunt.log.ok('Start deploying...');
+    grunt.task.run(['copy', 'wp_plugin', 'clean']);
+    grunt.log.ok('Deploy finished!');
+  });
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "homepage": "https://github.com/skroutz/skroutz-analytics-woocommerce#readme",
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-wp-i18n": "^0.5.4"
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-wp-i18n": "^0.5.4",
+    "grunt-wp-plugin": "skroutz/grunt-wp-plugin#v1.1.0-skroutz"
   }
 }


### PR DESCRIPTION
The deploy is done in 3 steps:
1. Copy to a `deploy` dir only the files that we want to be committed to the wordpress svn.
2. Run the wp_plugin task, that checkouts the svn repo to a `tmp`, creates a new version tag and commits the code.
3. Clean up the `deploy` and `tmp` folders.
