### PR TITLE
Use variation product id if applicable on reported item

### DIFF
--- a/includes/class-wc-skroutz-analytics-integration.php
+++ b/includes/class-wc-skroutz-analytics-integration.php
@@ -46,7 +46,10 @@ class WC_Skroutz_Analytics_Integration extends WC_Integration {
 		//Skroutz Analytics admin settings
 		$this->flavor = $this->get_option( 'sa_flavor' );
 		$this->shop_account_id  = $this->get_option( 'sa_shop_account_id' );
-		$this->items_product_id  = $this->get_option( 'sa_items_product_id' );
+		$this->items_product_id_settings = array(
+			'id' => $this->get_option( 'sa_items_product_id', 'sku' ),
+			'parent_id_enabled' => $this->get_option( 'sa_items_product_parent_id_enabled', 'no' ),
+		);
 
 		$this->register_admin_hooks();
 
@@ -55,7 +58,11 @@ class WC_Skroutz_Analytics_Integration extends WC_Integration {
 			return;
 		}
 
-		$this->tracking = new WC_Skroutz_Analytics_Tracking( $this->flavor, $this->shop_account_id, $this->items_product_id );
+		$this->tracking = new WC_Skroutz_Analytics_Tracking(
+			$this->flavor,
+			$this->shop_account_id,
+			$this->items_product_id_settings
+		);
 	}
 
 	/**
@@ -108,6 +115,10 @@ class WC_Skroutz_Analytics_Integration extends WC_Integration {
 				'options'     => array( 'sku' => 'Product SKU', 'id' => 'Product ID' ),
 				'default'     => 'sku',
 				'desc_tip'    => __( 'It must the same product ID used in the XML feed provided to Skroutz.', 'wc-skroutz-analytics' ),
+			),
+			'sa_items_product_parent_id_enabled' => array(
+				'type'	=> 'checkbox',
+				'label'	=> 'Always send parent product ID/SKU (variation ids will be ignored)',
 			),
 		);
 	}

--- a/includes/class-wc-skroutz-analytics-tracking.php
+++ b/includes/class-wc-skroutz-analytics-tracking.php
@@ -143,8 +143,7 @@ class WC_Skroutz_Analytics_Tracking {
 
 	/**
 	* Returns the product id that should be reported to Analytics based on
-	* product id admin setting. If the setting is SKU and the product SKU field
-	* is not set, a composite id is generated with the format wc-sa-{product id}
+	* product id admin settings.
 	*
 	* @param WC_Product $product The purchased WC product
 	* @return string|integer  The product id that should be reported to Analytics
@@ -153,11 +152,20 @@ class WC_Skroutz_Analytics_Tracking {
 	* @access   private
 	*/
 	private function sa_product_id( $product ) {
-		if($this->items_product_id == 'id') {
-			return $product->id;
+		$parent_or_variation = $product;
+
+		if($this->items_product_id_settings['parent_id_enabled'] == 'yes' && $product->is_type( 'variation' ) ) {
+			$parent_or_variation = $product->parent;
 		}
 
-		return $product->get_sku() ? $product->get_sku() : "wc-sa-{$product->id}";
+		if($this->items_product_id_settings['id'] == 'sku') {
+			$product_id = $parent_or_variation->get_sku();
+		} else {
+			// TODO: Use $product->get_id() when we drop support for WooCommerce < 2.6
+			$product_id = $parent_or_variation->is_type( 'variation' ) ? $parent_or_variation->get_variation_id() : $parent_or_variation->id;
+		}
+
+		return $product_id ? $product_id : "wc-sa-{$product->id}";
 	}
 
 	/**

--- a/includes/class-wc-skroutz-analytics-tracking.php
+++ b/includes/class-wc-skroutz-analytics-tracking.php
@@ -26,10 +26,13 @@ class WC_Skroutz_Analytics_Tracking {
 	private $shop_account_id;
 
 	/**
-	* The items product id option provided by the admin settings
-	* @var string
+	* The items product id options provided by the admin settings
+	*
+	* id: id|sku
+	* parent_id_enabled: yes|no
+	* @var array
 	*/
-	private $items_product_id;
+	private $items_product_id_settings;
 
 	/**
 	* The current order to be submitted
@@ -46,10 +49,10 @@ class WC_Skroutz_Analytics_Tracking {
 	*
 	* @since    1.0.0
 	*/
-	public function __construct( $flavor, $shop_account_id, $items_product_id ) {
+	public function __construct( $flavor, $shop_account_id, $items_product_id_settings ) {
 		$this->flavor = $flavor;
 		$this->shop_account_id = $shop_account_id;
-		$this->items_product_id = $items_product_id;
+		$this->items_product_id_settings = $items_product_id_settings;
 
 		// Page tracking script
 		add_action( 'wp_print_footer_scripts', array( $this, 'output_analytics_tracking_script' ) );


### PR DESCRIPTION
- Add an extra option to always send the parent product id/sku even if it is a variation product.
- Modify the reported product id based on the new option.
- Modify the behaviour of the product ID option. We used to send only the parent product id even if it was a variation product. We now check the type of the product and send the variation id instead if applicable.