### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/includes/class-wc-skroutz-analytics-tracking.php
+++ b/includes/class-wc-skroutz-analytics-tracking.php
@@ -200,7 +200,7 @@ class WC_Skroutz_Analytics_Tracking {
 	* @access   private
 	*/
 	private function get_custom_product_id( $product ) {
-		$product_id = NULL;
+		$product_id = null;
 
 		if ($this->items_product_id_settings['custom_id_enabled'] == 'yes' && $this->items_product_id_settings['custom_id']) {
 			$product_id = get_post_meta(


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!