### PR TITLE
Do not report an order to Analytics when the order status is failed

### DIFF
--- a/includes/class-wc-skroutz-analytics-tracking.php
+++ b/includes/class-wc-skroutz-analytics-tracking.php
@@ -68,6 +68,11 @@ class WC_Skroutz_Analytics_Tracking {
 	public function load_ecommerce_analytics( $order_id ) {
 		$this->order = new WC_Order( $order_id );
 
+		// Do not report an order to analytics when the order status is failed.
+		if ( $this->order->has_status( 'failed' ) ) {
+			return;
+		}
+
 		add_action( 'wp_print_footer_scripts', array( $this, 'output_ecommerce_analytics_script' ) );
 	}
 


### PR DESCRIPTION
[WooCommerce order management docs](https://docs.woocommerce.com/document/managing-orders/)

![](https://docs.woocommerce.com/wp-content/uploads/2013/05/woocommerce-order-process-diagram.png)

**Failed**: Payment failed or was declined (unpaid). The order can be manually cancelled, but this status can come up if the payment window has expired. It can happen for a few reasons:
* order was abandoned  before payment was complete
* The hold stock window expired without a response