### PR TITLE
Compatibility for Wordpress5.6 and WooCommerce 4.8

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: skroutz
 Tags: skroutz, alve, scrooge, analytics, woocommerce
 Requires at least: 4.0
-Tested up to: 5.5
+Tested up to: 5.6
 Stable tag: 1.6.4
 Requires PHP: 5.4
 License: GPL-2.0

--- a/includes/class-wc-skroutz-analytics-tracking.php
+++ b/includes/class-wc-skroutz-analytics-tracking.php
@@ -135,7 +135,14 @@ class WC_Skroutz_Analytics_Tracking {
 	* @return string The JavaScript representation of an Analytics Ecommerce addItem action.
 	*/
 	private function prepare_item_data( $item ) {
-		$product = $this->order->get_product_from_item( $item );
+		// WC_Abstract_Legacy_Order::get_product_from_item is deprecated since version 4.4.0
+		// TODO Use only WC_Order_Item_Product::get_product when we drop support for WooCommerce < 3.0
+		if ( method_exists( $item, 'get_product' ) ) {
+			$product = $item->get_product();
+		} else {
+			$product = $this->order->get_product_from_item( $item );
+		}
+
 		$sa_product = new WC_Skroutz_Analytics_Product( $product, $this->settings->get_product_id_settings() );
 
 		$data = array(

--- a/wc-skroutz-analytics.php
+++ b/wc-skroutz-analytics.php
@@ -23,7 +23,7 @@
  * Text Domain:       wc-skroutz-analytics
  * Domain Path:       /languages
  * WC requires at least: 2.5.0
- * WC tested up to: 4.3
+ * WC tested up to: 4.8
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
* Verify compatibility for Wordpress 5.6
* Verify compatibility for WooCommerce 4.8 (currently 4.3)
  * Fix deprecation warning for WC_Abstract_Legacy_Order::get_product_from_item (WooCommerce 4.4)